### PR TITLE
ci(release): add write permissions and fix GitHub token usage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -32,4 +35,4 @@ jobs:
           export HUSKY_SKIP_HOOKS=1
           pnpm run release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Grant release workflow write permissions for creating releases.
- Use standard `GITHUB_TOKEN` for authentication in release process.