### PR TITLE
ci(release): use GitHub App token for authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,10 +12,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: 'Generate token'
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.SEMANTIC_RELEASE_GITHUB_APP_ID }}
+          private_key: ${{ secrets.SEMANTIC_RELEASE_GITHUB_APP_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -35,4 +42,4 @@ jobs:
           export HUSKY_SKIP_HOOKS=1
           pnpm run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
- Replace the default GITHUB_TOKEN with a GitHub App installation token
- enable elevated permissions (e.g., force-push) in the release workflow

# PR Checklist

Please confirm and check all that apply:

- [ ] Code builds and tests pass locally
- [ ] Updated/added tests where appropriate
- [ ] Documentation updated (README/docs) if needed

## Environment variables

If this PR introduces or changes environment variables:

- [ ] Added placeholders and comments in `.env.example`
- [ ] Updated `config/env.required.json` for the right environments (development/preview/production)
- [ ] If secrets are required in Preview/Production, ensure they are set in Vercel (Project → Settings → Environment Variables)
- [ ] Verified CI passes the environment verification step

List variables introduced/changed (server vs public):

- Server: `VAR_A`, `VAR_B`
- Public (`NEXT_PUBLIC_*`): `NEXT_PUBLIC_VAR_X`

Notes for reviewers:

- Any migration steps for ops?
- Any default values or fallbacks added?
