### PR TITLE
ci(release): update github app token action to v2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - name: 'Generate token'
         id: generate_token
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@v2
         with:
-          app_id: ${{ secrets.SEMANTIC_RELEASE_GITHUB_APP_ID }}
-          private_key: ${{ secrets.SEMANTIC_RELEASE_GITHUB_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.SEMANTIC_RELEASE_GITHUB_APP_ID }}
+          private-key: ${{ secrets.SEMANTIC_RELEASE_GITHUB_APP_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Switch from tibdex/github-app-token@v1 to actions/create-github-app-token@v2
and adjust input parameters accordingly

# PR Checklist

Please confirm and check all that apply:

- [ ] Code builds and tests pass locally
- [ ] Updated/added tests where appropriate
- [ ] Documentation updated (README/docs) if needed

## Environment variables

If this PR introduces or changes environment variables:

- [ ] Added placeholders and comments in `.env.example`
- [ ] Updated `config/env.required.json` for the right environments (development/preview/production)
- [ ] If secrets are required in Preview/Production, ensure they are set in Vercel (Project → Settings → Environment Variables)
- [ ] Verified CI passes the environment verification step

List variables introduced/changed (server vs public):

- Server: `VAR_A`, `VAR_B`
- Public (`NEXT_PUBLIC_*`): `NEXT_PUBLIC_VAR_X`

Notes for reviewers:

- Any migration steps for ops?
- Any default values or fallbacks added?
